### PR TITLE
active-storage download bug omit

### DIFF
--- a/lib/rails-footnotes/filter.rb
+++ b/lib/rails-footnotes/filter.rb
@@ -65,7 +65,12 @@ module Footnotes
       @notes = []
 
       revert_pos(controller.response_body) do
-        @body = controller.response.body
+        @body =
+          begin
+            controller.response.body
+          rescue Exception => e
+            self.class.log_error("Footnotes::Filter initialize Exception", e)
+          end
       end
     end
 


### PR DESCRIPTION
railsのactive-storageでローカル環境のstorageファイルからのファイルダウンロード時にerrorが発生する。

原因
controller.response.bodyの呼び先の
https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/http/response.rb#L323
の@streamがactive_storageのダウンロード時にundefineになることがあり、@stream.bodyがundefine method error を投げる。

解決
controller.response.bodyのエラーをだす場合があるのでbegin rescueでエラーキャッチをする。