### PR TITLE
[gemspec] Remove deprecated `s.rubyforge_project=`

### DIFF
--- a/rails-footnotes.gemspec
+++ b/rails-footnotes.gemspec
@@ -12,8 +12,6 @@ Gem::Specification.new do |s|
   s.summary     = %q{Every Rails page has footnotes that gives information about your application and links back to your editor.}
   s.description = %q{Every Rails page has footnotes that gives information about your application and links back to your editor.}
 
-  s.rubyforge_project = "rails-footnotes"
-
   s.add_dependency "rails", ">= 3.2"
 
   s.add_development_dependency "rspec-rails", '~> 3.3.2'


### PR DESCRIPTION
Fixes #164.