### PR TITLE
Limit rake version under 11 to avoid conflict with rspec-rails 3.3.2

### DIFF
--- a/rails-footnotes.gemspec
+++ b/rails-footnotes.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", ">= 3.2"
 
+  s.add_development_dependency "rake", '< 11.0'
   s.add_development_dependency "rspec-rails", '~> 3.3.2'
   s.add_development_dependency "sprockets-rails", '~> 2.0'
   s.add_development_dependency "capybara"


### PR DESCRIPTION
This should resolve CI failures, currently caused by this issue: https://stackoverflow.com/questions/35893584/nomethoderror-undefined-method-last-comment-after-upgrading-to-rake-11.

Since Rake 11 removes the last_comment method that is used by rspec 3.3.2, either the minimum dependency for rspec-rails must changed, or the rake version must be limited. I would suggest eventually raising the rspec version, along with a broader push for Rails 5/6 compatibility, but for now this conservative approach should at least ensure the CI build uses a version of rake that will not give this error.

Note: I hope merging this change would also allow merging #157. I have also run into the issue reported in #153, and have otherwise had no issues using the gem with Rails 5 after fixing the writter/writer typo. I considered including those changes in one PR, but decided they are really separate, and the other issue is already resolved by that PR. The CI failures are otherwise unrelated to those changes, I have validated that the build passes with both changes, so that should become green after making this change.